### PR TITLE
feat: support english-specific question templates

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -81,6 +81,9 @@ def generate_handler():
         "Ensure the questions are aligned with the Singapore MOE syllabus. "
     )
 
+    if data.get('subject') == 'English' and data.get('template'):
+        prompt += f"\nUse the following question template for formatting:\n{data['template']}"
+
     # Add instruction to avoid repeating questions if a history is provided
     previous_questions = data.get('previous_questions', [])
     if previous_questions:
@@ -102,7 +105,22 @@ def generate_handler():
     generation_config = {
         "responseMimeType": "application/json",
         "responseSchema": {
-            "type": "OBJECT", "properties": { "questions": { "type": "ARRAY", "items": { "type": "OBJECT", "properties": { "type": {"type": "STRING"}, "question": {"type": "STRING"}, "options": {"type": "ARRAY", "items": {"type": "STRING"}} }, "required": ["type", "question"] } } }
+            "type": "OBJECT",
+            "properties": {
+                "questions": {
+                    "type": "ARRAY",
+                    "items": {
+                        "type": "OBJECT",
+                        "properties": {
+                            "type": {"type": "STRING"},
+                            "question": {"type": "STRING"},
+                            "options": {"type": "ARRAY", "items": {"type": "STRING"}},
+                            "image": {"type": "STRING"}
+                        },
+                        "required": ["type", "question"]
+                    }
+                }
+            }
         }
     }
     return call_gemini_api(prompt, generation_config)

--- a/index.html
+++ b/index.html
@@ -218,6 +218,13 @@
                 English: []
             },
         };
+        const englishTemplates = {
+            'Vocabulary MCQ': `My grandmother always tells me a ______ before I go to bed.\n\n1) poem 2) story 3) map 4) game\n(    )`,
+            'Grammar MCQ': `She ______ going to the library tomorrow.\n\n1) is 2) are 3) was 4) were\n(    )`,
+            'Grammar Cloze': `Fill in each blank with the correct word. Choose from the options given.\n\nPassage:\n\nLast Saturday, my family and I went to the zoo. There (9) ______ many people at the entrance. We (10) ______ our tickets and entered quickly. My sister (11) ______ very excited when she saw the giraffes. We also (12) ______ to the penguin enclosure to watch them swim.\n\nOptions for blanks (each used once):\n\nwere\n\nbought\n\nwas\n\nwent\n\n9. ______\n10. ______\n11. ______\n12. ______`,
+            'Comprehension Visual Text': `Include an 'image' field with a URL displayed above the question text and options.`,
+            'Comprehension Open Ended': `Include an 'image' field with a URL at the top, followed by an open-ended question about the image.`
+        };
         const stickers = ['⭐', '👍', '🎉', '🏆', '💯', '✨', '🤩', '🚀'];
 
         // --- App State ---
@@ -545,6 +552,9 @@
                 
                 params.previous_questions = [...new Set(previousQuestions)];
 
+                if (params.subject === 'English') {
+                    params.template = englishTemplates[params.topic] || '';
+                }
                 const response = await callBackendAPI('/api/generate', params);
                 questions = response.questions;
                 displayQuestions();
@@ -595,13 +605,18 @@
                             <div id="answer-${index}" class="rich-text-editor bg-white" contenteditable="true"></div>`;
                         break;
                 }
-                qElement.innerHTML = `
+                let headerHtml = `
                     <div class="flex justify-between items-start">
                         <p class="font-semibold text-lg text-slate-800 mb-2 flex-grow">${index + 1}. ${q.question}</p>
                         <button id="hint-btn-${index}" onclick="getHint(${index})" class="hint-button text-white font-bold py-1 px-3 rounded-lg text-sm ml-4 flex-shrink-0">
                             <i class="fas fa-lightbulb"></i> Hint
                         </button>
-                    </div>
+                    </div>`;
+                if (q.image) {
+                    headerHtml = `<div class="mb-4 text-center"><img src="${q.image}" alt="Question Image" class="max-w-full h-auto mx-auto rounded"/></div>` + headerHtml;
+                }
+                qElement.innerHTML = `
+                    ${headerHtml}
                     ${answerHtml}
                     <div id="hint-text-${index}" class="hidden mt-2 p-2 hint-text rounded"></div>
                 `;


### PR DESCRIPTION
## Summary
- add predefined English question templates for vocabulary, grammar, comprehension, and cloze formats
- send selected English templates to backend and render images above comprehension questions
- allow API to accept template guidance and optional image field in schema

## Testing
- `python -m py_compile api/index.py`


------
https://chatgpt.com/codex/tasks/task_b_68a272c3b318832eaea4b457b017e6c7