### PR TITLE
Standardize English MCQ templates and add shared comprehension image

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -69,20 +69,36 @@ def generate_handler():
         return jsonify({"error": f"Missing or empty required fields: {', '.join(missing_fields)}"}), 400
 
     # Build the base prompt
-    prompt = (
-        f"Act as a Primary School teacher in Singapore. "
-        f"Generate a quiz with exactly 5 questions for a {data['classLevel']} student. "
-        f"The subject is {data['subject']} and the specific topic is {data['topic']}. "
-        f"The difficulty level should be {data['difficulty']}. "
-        "The quiz must have this structure: "
-        "1. Two 'single-choice' questions (select one correct answer from 4 options). "
-        "2. One 'multi-select' question (select one or more correct answers from 4 options). "
-        "3. Two 'free-text' questions (open-ended questions requiring a written answer). "
-        "Ensure the questions are aligned with the Singapore MOE syllabus. "
-    )
+    english_mcq_topics = {"Vocabulary MCQ", "Grammar MCQ", "Grammar Cloze"}
+    comprehension_topics = {"Comprehension Visual Text", "Comprehension Open Ended"}
+
+    if data.get('subject') == 'English' and data.get('topic') in english_mcq_topics:
+        prompt = (
+            f"Act as a Primary School teacher in Singapore. "
+            f"Generate a quiz with exactly 5 'single-choice' multiple-choice questions for a {data['classLevel']} student. "
+            f"The subject is {data['subject']} and the specific topic is {data['topic']}. "
+            f"The difficulty level should be {data['difficulty']}. "
+            "Each question must have four options with exactly one correct answer. "
+            "Ensure the questions are aligned with the Singapore MOE syllabus. "
+        )
+    else:
+        prompt = (
+            f"Act as a Primary School teacher in Singapore. "
+            f"Generate a quiz with exactly 5 questions for a {data['classLevel']} student. "
+            f"The subject is {data['subject']} and the specific topic is {data['topic']}. "
+            f"The difficulty level should be {data['difficulty']}. "
+            "The quiz must have this structure: "
+            "1. Two 'single-choice' questions (select one correct answer from 4 options). "
+            "2. One 'multi-select' question (select one or more correct answers from 4 options). "
+            "3. Two 'free-text' questions (open-ended questions requiring a written answer). "
+            "Ensure the questions are aligned with the Singapore MOE syllabus. "
+        )
 
     if data.get('subject') == 'English' and data.get('template'):
         prompt += f"\nUse the following question template for formatting:\n{data['template']}"
+
+    if data.get('subject') == 'English' and data.get('topic') in comprehension_topics:
+        prompt += ("\nAll five questions must be based on the same image. Include an 'image' field with the same URL for each question.")
 
     # Add instruction to avoid repeating questions if a history is provided
     previous_questions = data.get('previous_questions', [])

--- a/index.html
+++ b/index.html
@@ -221,9 +221,9 @@
         const englishTemplates = {
             'Vocabulary MCQ': `My grandmother always tells me a ______ before I go to bed.\n\n1) poem 2) story 3) map 4) game\n(    )`,
             'Grammar MCQ': `She ______ going to the library tomorrow.\n\n1) is 2) are 3) was 4) were\n(    )`,
-            'Grammar Cloze': `Fill in each blank with the correct word. Choose from the options given.\n\nPassage:\n\nLast Saturday, my family and I went to the zoo. There (9) ______ many people at the entrance. We (10) ______ our tickets and entered quickly. My sister (11) ______ very excited when she saw the giraffes. We also (12) ______ to the penguin enclosure to watch them swim.\n\nOptions for blanks (each used once):\n\nwere\n\nbought\n\nwas\n\nwent\n\n9. ______\n10. ______\n11. ______\n12. ______`,
-            'Comprehension Visual Text': `Include an 'image' field with a URL displayed above the question text and options.`,
-            'Comprehension Open Ended': `Include an 'image' field with a URL at the top, followed by an open-ended question about the image.`
+            'Grammar Cloze': `She ______ to the park every Saturday.\n\n1) go 2) goes 3) going 4) gone\n(    )`,
+            'Comprehension Visual Text': `Use a single 'image' field with a URL that applies to all five questions. Display the image above the question text and options for each question.`,
+            'Comprehension Open Ended': `Use a single 'image' field with a URL that applies to all five questions. Display the image above each open-ended question about the image.`
         };
         const stickers = ['⭐', '👍', '🎉', '🏆', '💯', '✨', '🤩', '🚀'];
 


### PR DESCRIPTION
## Summary
- Align Vocabulary MCQ, Grammar MCQ, and Grammar Cloze templates to the same multiple-choice format
- Ensure comprehension quizzes reference a single image and instruct API to include the image URL for every question
- Generate five single-choice questions for English MCQ topics

## Testing
- `python -m py_compile api/index.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2752e8630832e84c1bd508d3b2a0b