### PR TITLE
Fix quiz generation requests that omit topic/difficulty

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -95,7 +95,7 @@ def call_gemini_api(prompt, generation_config=None):
         return jsonify({"error": "An internal server error occurred."}), 500
 
 def _handle_generate_quiz(data):
-    required_fields = ['classLevel', 'subject', 'topic', 'difficulty']
+    required_fields = ['classLevel', 'subject']
 
     if not data:
         return _json_error("Request body must be JSON.")
@@ -104,25 +104,33 @@ def _handle_generate_quiz(data):
     if missing_fields:
         return _json_error(f"Missing or empty required fields: {', '.join(missing_fields)}")
 
+    class_level = str(data.get('classLevel', '')).strip()
+    subject = str(data.get('subject', '')).strip()
+    topic = str(data.get('topic') or '').strip() or f"General {subject} practice"
+    difficulty = str(data.get('difficulty') or '').strip() or 'Medium'
+
+    if not class_level or not subject:
+        return _json_error("Missing or empty required fields: classLevel, subject")
+
     # Build the base prompt
     english_mcq_topics = {"Vocab MCQ", "Grammar MCQ", "Grammar Cloze", "Comprehension Cloze"}
     comprehension_topics = {"Comprehension (Open-Ended)"}
 
-    if data.get('subject') == 'English' and data.get('topic') in english_mcq_topics:
+    if subject == 'English' and topic in english_mcq_topics:
         prompt = (
             f"Act as a Primary School teacher in Singapore. "
-            f"Generate a quiz with exactly 5 'single-choice' multiple-choice questions for a {data['classLevel']} student. "
-            f"The subject is {data['subject']} and the specific topic is {data['topic']}. "
-            f"The difficulty level should be {data['difficulty']}. "
+            f"Generate a quiz with exactly 5 'single-choice' multiple-choice questions for a {class_level} student. "
+            f"The subject is {subject} and the specific topic is {topic}. "
+            f"The difficulty level should be {difficulty}. "
             "Each question must have four options with exactly one correct answer. "
             "Ensure the questions are aligned with the Singapore MOE syllabus. "
         )
     else:
         prompt = (
             f"Act as a Primary School teacher in Singapore. "
-            f"Generate a quiz with exactly 5 questions for a {data['classLevel']} student. "
-            f"The subject is {data['subject']} and the specific topic is {data['topic']}. "
-            f"The difficulty level should be {data['difficulty']}. "
+            f"Generate a quiz with exactly 5 questions for a {class_level} student. "
+            f"The subject is {subject} and the specific topic is {topic}. "
+            f"The difficulty level should be {difficulty}. "
             "The quiz must have this structure: "
             "1. Two 'single-choice' questions (select one correct answer from 4 options). "
             "2. One 'multi-select' question (select one or more correct answers from 4 options). "
@@ -130,10 +138,10 @@ def _handle_generate_quiz(data):
             "Ensure the questions are aligned with the Singapore MOE syllabus. "
         )
 
-    if data.get('subject') == 'English' and data.get('template'):
+    if subject == 'English' and data.get('template'):
         prompt += f"\nUse the following question template for formatting:\n{data['template']}"
 
-    if data.get('subject') == 'English' and data.get('topic') in comprehension_topics:
+    if subject == 'English' and topic in comprehension_topics:
         prompt += ("\nAll five questions must be based on the same image. Include an 'image' field with the same URL for each question.")
 
     # Add instruction to avoid repeating questions if a history is provided


### PR DESCRIPTION
### Motivation
- Some clients send partial payloads when starting quiz generation and the previous strict validation returned `400 Bad Request`, preventing generation from proceeding.
- The goal is to make `/api/generate` resilient to missing `topic` and `difficulty` while preserving normal behaviour when those fields are provided.

### Description
- Relax `/api/generate` validation to require only `classLevel` and `subject` and accept requests that omit `topic` and `difficulty` by defaulting them. 
- Normalize inputs into local variables (`class_level`, `subject`, `topic`, `difficulty`) and use those when building prompts to avoid empty-string edge cases. 
- Default `topic` to `General <subject> practice` and `difficulty` to `Medium` when not provided. 
- Adjust English-specific branching and template/image checks to reference the normalized `subject`/`topic` values.

### Testing
- `python -m py_compile api/index.py` succeeded.
- Flask test client POST to `POST /api/generate` with `{'classLevel':'P3','subject':'Maths'}` passed input validation and reached the API-key check (server returned a 500 with `API key is not configured on the server.`), confirming the 400 validation path was removed.
- A live `curl` check against the deployed Vercel URL failed with a network/proxy `403` in this environment, so deployment endpoint verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699062c83e84832ea3e79567e8ee3518)